### PR TITLE
key warning issue

### DIFF
--- a/packages/igeeks-theme/src/components/home/slider/slider.js
+++ b/packages/igeeks-theme/src/components/home/slider/slider.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {Fragment} from "react";
 import Slider from "@farbenmeer/react-spring-slider";
 import { Button, Text, Box, Flex, Image } from "rebass";
 import { css, connect } from "frontity";
@@ -52,9 +52,9 @@ const Carousel = ({ state, data }) => {
                 // RightArrowComponent={rightArrowComponent}
                 auto={6000}
             >
-                {data.map(item => {
+                {data.map((item, index) => {
                     return (
-                        <>
+                        <Fragment key={index}>
                             {state.source.attachment[item.featured_media] && (
                                 <ProgressiveSlider
                                     style={imageStyle(state.source.attachment[item.featured_media].source_url)}
@@ -91,7 +91,7 @@ const Carousel = ({ state, data }) => {
                                     {item.title.rendered.replace("&#8217;s", "'s ")}
                                 </Text>
                             </div>
-                        </>
+                        </Fragment>
                     );
                 })}
             </Slider>


### PR DESCRIPTION
This PR fixes this warning 

```
Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <Slider>. See https://fb.me/react-warning-keys for more information.
    in Fragment
    in Unknown
    in Unknown
    in InnerLoadable
    in Context.Consumer
    in Unknown
    in ForwardRef
    in Fragment
    in Unknown
    in Unknown
    in Fragment
    in Context.Provider
    in Context.Consumer
    in ThemeProvider
    in Unknown
    in Unknown
    in Context.Provider
    in Context.Provider
    in HelmetProvider
    in App
    in Context.Provider
    in ChunkExtractorManager
```
